### PR TITLE
runner: Unset skiplangupgrade for end of on-sync period

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -28,7 +28,7 @@ $CFG->prefix    = 'm_';
 $CFG->dboptions = ['dbcollation' => getenv('DBCOLLATION')];
 
 // Skip language upgrade during the on-sync period.
-$CFG->skiplangupgrade = true;
+$CFG->skiplangupgrade = false;
 
 $CFG->wwwroot   = 'http://host.name';
 $CFG->dataroot  = '/var/www/moodledata';


### PR DESCRIPTION
Note: This pull request should not be completed until the end of the on-sync period.
See https://docs.moodle.org/dev/Release_process#2_weeks_after for further information