### PR TITLE
runner: Add Ionic testing

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -118,8 +118,13 @@ if ($redistestname = getenv('REDISTESTNAME')) {
     }
     define('TEST_CACHESTORE_REDIS_TESTSERVERS', $redistestname);
 }
+
 if (!empty(getenv('EXTTESTURL'))) {
     define('TEST_EXTERNAL_FILES_HTTP_URL', getenv('EXTTESTURL'));
+}
+
+if ($ionicurl = getenv('IONICURL')) {
+    $CFG->behat_ionic_wwwroot = $ionicurl;
 }
 
 require_once(__DIR__ . '/lib/setup.php');


### PR DESCRIPTION
Add ionic container and configuration to support behat mobile app testing.

Note: This required some changes to look for healthy images. We should look to see if we can add health checks them for other images too (Oracle, etc).