### PR TITLE
runner: Avoid local network collissions

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -164,8 +164,8 @@ trap ctrl_c INT
 echo
 echo ">>> startsection Checking networks <<<"
 echo "============================================================================"
-NETWORKNAME="moodle"
-NETWORK=$(docker network list -q --filter name="${NETWORKNAME}")
+NETWORKNAME="${NETWORKNAME:-moodle}"
+NETWORK=$(docker network list -q --filter name="${NETWORKNAME}$")
 if [[ -z ${NETWORK} ]]
 then
     echo "Creating new network '${NETWORKNAME}'"


### PR DESCRIPTION
When running it locally, a couple of issues have been identified:

- There are collisions if there are other local networks called `moodle*`. The filter for searching the NETWORKNAME has been changed to fix it.
- The owner for the /var/www folder has been also changed to www-data for the PHPUnit tests.