### PR TITLE
Enable back Redis session tests for PHP 7.2 and up

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -116,10 +116,7 @@ if ($solrtestname = getenv('SOLRTESTNAME')) {
 }
 
 if ($redistestname = getenv('REDISTESTNAME')) {
-    // We need to keep Redis session tests disabled for PHP 7.2 and up. See MDL-60978.
-    if (version_compare(PHP_VERSION, '7.2.0', '<')) {
-        define('TEST_SESSION_REDIS_HOST', $redistestname);
-    }
+    define('TEST_SESSION_REDIS_HOST', $redistestname);
     define('TEST_CACHESTORE_REDIS_TESTSERVERS', $redistestname);
 }
 

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -385,7 +385,7 @@ then
       --network "${NETWORK}" \
       --name ${IONICHOSTNAME} \
       --detach \
-      moodlehq/moodlemobile2:3.6.1
+      moodlehq/moodlemobile2:latest
 
     export "IONICURL"="http://${IONICHOSTNAME}:8100"
     echo "IONICURL" >> "${ENVIROPATH}"


### PR DESCRIPTION
This reverts commit f36e8081c50dfa7342b9e91736c1febeeedebbd6.

(done as part of https://tracker.moodle.org/browse/MDLSITE-5876)

Note that, at the very same time... I also have unpinned the mobile version, now that all the @app tests have been removed from core by https://tracker.moodle.org/browse/MDL-65869).

Ciao :-)