### PR TITLE
Revert "Moving away from 3.141.59-neon coz it's causing problems"

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -390,7 +390,7 @@ then
     export "IONICURL"="http://${IONICHOSTNAME}:8100"
     echo "IONICURL" >> "${ENVIROPATH}"
 
-    SELVERSION="3.141.59-mercury"
+    SELVERSION="3.141.59"
     ITER=0
     while [[ ${ITER} -lt ${BEHAT_TOTAL_RUNS} ]]
     do


### PR DESCRIPTION
This reverts commit 1bda1c27f698e5a96180836b59b19f254b5fbd58.

Fixed by way of MDL-66378.