### PR TITLE
Revert "Revert "Moving away from 3.141.59-neon coz it's causing problems""

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -390,7 +390,7 @@ then
     export "IONICURL"="http://${IONICHOSTNAME}:8100"
     echo "IONICURL" >> "${ENVIROPATH}"
 
-    SELVERSION="3.141.59"
+    SELVERSION="3.141.59-mercury"
     ITER=0
     while [[ ${ITER} -lt ${BEHAT_TOTAL_RUNS} ]]
     do


### PR DESCRIPTION
Reverts moodlehq/moodle-ci-runner#7

Can we fit the word revert in any more?

Workplace don't have the patch for 66378 yet. We should wait for them first.