### PR TITLE
Unpin 3.141.59-mercury and allow any new 3.x release to be used

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -390,7 +390,7 @@ then
     export "IONICURL"="http://${IONICHOSTNAME}:8100"
     echo "IONICURL" >> "${ENVIROPATH}"
 
-    SELVERSION="3.141.59-mercury"
+    SELVERSION="3"
     ITER=0
     while [[ ${ITER} -lt ${BEHAT_TOTAL_RUNS} ]]
     do


### PR DESCRIPTION
With [MDL-66378](https://tracker.moodle.org/browse/MDL-66378) and, specially, https://github.com/moodlehq/php-webdriver/pull/1
we can continue using Chrome >= 76 because we are enforcing the
use of the legacy JsonWire protocol (instead of the default W3C one).

So it has been agreed that we'll allow any 3.x new release to be used in
order to detect problems earlier (we always can pin again if needed).

Note that I've applied for the very same change @ https://github.com/moodlehq/moodle-docker/pull/107 and it's running some complete @javascript runs with it.