### PR TITLE
runner: Set skiplangupgrade as part of on-sync period

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -28,7 +28,7 @@ $CFG->prefix    = 'm_';
 $CFG->dboptions = ['dbcollation' => getenv('DBCOLLATION')];
 
 // Skip language upgrade during the on-sync period.
-$CFG->skiplangupgrade = false;
+$CFG->skiplangupgrade = true;
 
 $CFG->wwwroot   = 'http://host.name';
 $CFG->dataroot  = '/var/www/moodledata';


### PR DESCRIPTION
This is MR3 in the [release process](https://docs.moodle.org/dev/Release_process#1_week_prior)