### PR TITLE
Avoid Chrome 80 because it's causing some SCORM tests to fail

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -473,7 +473,7 @@ then
       echo "IONICURL" >> "${ENVIROPATH}"
     fi
 
-    SELVERSION="3"
+    SELVERSION="3.141.59-zinc"
     ITER=0
     while [[ ${ITER} -lt ${BEHAT_TOTAL_RUNS} ]]
     do


### PR DESCRIPTION
See https://tracker.moodle.org/browse/MDL-67989 for more information,
once that is solved, we'll revert this, proceeding with #21