### PR TITLE
Make unit tests also use exttests docker container for https tests

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -144,6 +144,7 @@ if ($mongodbtesturl = getenv('MONGODBTESTURL')) {
 
 if (!empty(getenv('EXTTESTURL'))) {
     define('TEST_EXTERNAL_FILES_HTTP_URL', getenv('EXTTESTURL'));
+    define('TEST_EXTERNAL_FILES_HTTPS_URL', getenv('EXTTESTURL'));
 }
 
 if ($ionicurl = getenv('IONICURL')) {


### PR DESCRIPTION
While we are already using the exttests docker image for HTTP
requests (avoiding to use download.moodle.org), we are not using
it for HTTPS tests.

Looking to codebase, there is only ONE tests using HTTPS and it's
the one that uses to fail when there are porblems with downloads.

As far as that test doesn't perform any check or validation related
to certificates, we can, simply, configure unit tests to also use
the HTTP exttests URL to run the HTTPS test.

If tomorrow we need some real HTTPS test, surely we'll need to
incorporate some mutual recognised certificates, or a real one..

But right now that's not needed.