### PR TITLE
Disable lang upgrades, to be enabled once the lang branch is available

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -38,7 +38,7 @@ if ($slave = getenv('DBHOST_SLAVE')) {
 }
 
 // Skip language upgrade during the on-sync period.
-$CFG->skiplangupgrade = false;
+$CFG->skiplangupgrade = true;
 
 $CFG->wwwroot   = 'http://host.name';
 $CFG->dataroot  = '/var/www/moodledata';


### PR DESCRIPTION
Normally we do this on release, when branching. But We are branching 310 earlier, so we need these tests disabled for a while (till the 310 lang packs are available).