### PR TITLE
Unpin MariaDB and remove deprecated / removed settings from config

### DIFF
--- a/runner/master/mysql.d/master/conf.d/master.cnf
+++ b/runner/master/mysql.d/master/conf.d/master.cnf
@@ -2,9 +2,7 @@
 default-character-set = utf8mb4
 
 [mysqld]
-innodb_file_format = Barracuda
 innodb_file_per_table = 1
-innodb_large_prefix = On
 
 character-set-server = utf8mb4
 collation-server = utf8mb4_bin

--- a/runner/master/mysql.d/slave/config/moodle.cnf
+++ b/runner/master/mysql.d/slave/config/moodle.cnf
@@ -2,9 +2,7 @@
 default-character-set = utf8mb4
 
 [mysqld]
-innodb_file_format = Barracuda
 innodb_file_per_table = 1
-innodb_large_prefix = On
 
 character-set-server = utf8mb4
 collation-server = utf8mb4_bin

--- a/runner/master/mysql.d/standalone/conf.d/moodle.cnf
+++ b/runner/master/mysql.d/standalone/conf.d/moodle.cnf
@@ -2,9 +2,7 @@
 default-character-set = utf8mb4
 
 [mysqld]
-innodb_file_format = Barracuda
 innodb_file_per_table = 1
-innodb_large_prefix = On
 
 character-set-server = utf8mb4
 collation-server = utf8mb4_bin

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -324,7 +324,7 @@ then
       --tmpfs /var/lib/mysql:rw \
       -v $SCRIPTPATH/mysql.d/master/conf.d:/etc/mysql/conf.d \
       -v $SCRIPTPATH/mysql.d/master/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d \
-      mariadb:10.2
+      mariadb
 
     echo "Starting slave"
     docker run \
@@ -340,7 +340,7 @@ then
       -v $SCRIPTPATH/mysql.d/slave/config:/config \
       -v $SCRIPTPATH/mysql.d/slave/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d \
       --tmpfs /var/lib/mysql:rw \
-      mariadb:10.2
+      mariadb
 
     # Hack to make gosu work for all users on the slave.
     docker exec -u root $DBHOST_SLAVE bash -c 'chown root:mysql /usr/local/bin/gosu'
@@ -357,7 +357,7 @@ then
       -e MYSQL_PASSWORD="${DBPASS}" \
       --tmpfs /var/lib/mysql:rw \
       -v $SCRIPTPATH/mysql.d/standalone/conf.d:/etc/mysql/conf.d \
-      mariadb:10.2
+      mariadb
   fi
 
   export DBCOLLATION=utf8mb4_bin


### PR DESCRIPTION
this shouldn't affect MySQL because current (5.7 and up) defaults
match the settings too.

Has been tested against 35_STABLE and master, with all PHP versions @ https://github.com/moodlehq/moodle-docker/pull/134#issuecomment-691329406 , using the testing branch. All worked ok (the problems there are 1) a known random and 2) a solr php71 problem that has been fixed already.

Ciao :-)