### PR TITLE
Enable lang upgrades again

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -38,7 +38,7 @@ if ($slave = getenv('DBHOST_SLAVE')) {
 }
 
 // Skip language upgrade during the on-sync period.
-$CFG->skiplangupgrade = true;
+$CFG->skiplangupgrade = false;
 
 $CFG->wwwroot   = 'http://host.name';
 $CFG->dataroot  = '/var/www/moodledata';


### PR DESCRIPTION
Note: This pull request should not be completed until the end of the on-sync period.
See https://docs.moodle.org/dev/Release_process#2_weeks_after for further information

Under parallel development, until the new dev branch (310_STABLE in this
case) language packs are and available. They are now: https://download.moodle.org/langpack/3.10/