### PR TITLE
runner: Always show Job summary

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -175,7 +175,8 @@ echo "BEHAT_NUM_RERUNS" >> "${ENVIROPATH}"
 echo "BEHAT_TIMING_FILENAME" >> "${ENVIROPATH}"
 echo "BEHAT_INCREASE_TIMEOUT" >> "${ENVIROPATH}"
 
-echo ">>> startsection Job summary <<<"
+echo "============================================================================"
+echo "= Job summary <<<"
 echo "============================================================================"
 echo "== Workspace: ${WORKSPACE}"
 echo "== Build Id: ${BUILD_ID}"
@@ -199,7 +200,6 @@ echo "== PLUGINSTOINSTALL: ${PLUGINSTOINSTALL}"
 echo "== TESTSUITE: ${TESTSUITE}"
 echo "== Environment: ${ENVIROPATH}"
 echo "============================================================================"
-echo ">>> stopsection <<<"
 
 # Setup the image cleanup.
 function finish {


### PR DESCRIPTION
Remove the section tags which cause Jenkins to collapse the Job summary.

The job summary is often useful when identifying jobs and it is unnecessarily collapsed in a section.