### PR TITLE
Stop running ionic when not testing mobile

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -592,7 +592,7 @@ then
   if [ "$BROWSER" == "chrome" ]
   then
 
-    if [ ! -z "$MOBILE_VERSION" ]
+    if [ ! -z "$MOBILE_VERSION" ] && [ -d "${PLUGINSDIR}/local/moodlemobileapp" ]
     then
       # Only run the moodlemobile docker container when the MOBILE_VERSION is defined.
       IONICHOSTNAME="ionic${UUID}"


### PR DESCRIPTION
On CI we always fill the value of MOBILE_VERSION, so ionic is always started. Sometimes this takes a full minute, and nothing is happening and it's never used.