### PR TITLE
Disable accessibility (axe) with classic till MDL-70846 is fixed

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -795,17 +795,22 @@ then
     fi
   fi
 
+  AXE=""
+  # Accesibility tests disabled for classic until MDL-70846 is fixed.
+  if [ "${BEHAT_SUITE}" != "classic" ];
+  then
+    AXE="--axe"
+  fi
+
   echo php admin/tool/behat/cli/init.php \
-      ${BEHAT_INIT_SUITE} \
-      --axe \
+      ${BEHAT_INIT_SUITE} ${AXE} \
       -j="${BEHAT_TOTAL_RUNS}"
 
   docker exec -t "${WEBSERVER}" bash -c 'chown -R www-data:www-data /var/www/*'
 
   docker exec -t -u www-data "${WEBSERVER}" \
     php admin/tool/behat/cli/init.php \
-      ${BEHAT_INIT_SUITE} \
-      --axe \
+      ${BEHAT_INIT_SUITE} ${AXE} \
       -j="${BEHAT_TOTAL_RUNS}"
 else
   docker exec -t -u www-data "${WEBSERVER}" \


### PR DESCRIPTION
Recently we enabled accessibility tests for all runs. But it seems that we have some problems under classic that have been reported @ [MDL-70846](https://tracker.moodle.org/browse/MDL-70846).

Those failures make all classic builds to consistently fail, what is really useless and can hide other, unknown unless you look to all failures, problems.

So this PR just disables those accessibility tests (aka, the `--axe` switch) when the suite (theme) is classic.

If approved, I'll create an issue to revert this PR once the upstream problem commented above is fixed.

Have tested it locally and seems to work ok.

- With "default":
````
...
>>> startsection Initialising test environment<<<
============================================================================
php admin/tool/behat/cli/init.php -a=default --axe -j=1
...
Moodle 4.0dev (Build: 20210211), 41037efa7a0c1cd20640de9b68c72584d5a78510
Php: 7.4.12, pgsql: 9.6.20, OS: Linux 4.19.121-linuxkit x86_64
Run optional tests:
- Accessibility: Yes
Server OS "Linux", Browser: "chrome"
...
````

- With "classic":
````
>>> startsection Initialising test environment<<<
============================================================================
php admin/tool/behat/cli/init.php -a=classic -j=1
...
Moodle 4.0dev (Build: 20210211), 41037efa7a0c1cd20640de9b68c72584d5a78510
Php: 7.4.12, pgsql: 9.6.20, OS: Linux 4.19.121-linuxkit x86_64
Run optional tests:
- Accessibility: No
Server OS "Linux", Browser: "chrome"
...
````