### PR TITLE
Unpin selenium 3.141.59-zinc (Chrome 79) so 89 takes the baton

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -608,10 +608,6 @@ then
   SELCHROMEIMAGE="selenium/standalone-chrome:${SELVERSION}"
   SELFIREFOXIMAGE="selenium/standalone-firefox:${SELVERSION}"
 
-  # Pin Chrome to 3.141.59-zinc until Chrome 89 is released around 02/03/2021.
-  # See https://bugs.chromium.org/p/chromedriver/issues/detail?id=3682&q=&can=1&sort=-id
-  SELCHROMEIMAGE="selenium/standalone-chrome:3.141.59-zinc"
-
   # Newer versions of Firefox do not allow Marionette to be disabled.
   # Version 47.0.1 is the latest version of Firefox we can support when Marionette is disabled.
   if [[ ${DISABLE_MARIONETTE} -ge 1 ]]


### PR DESCRIPTION
We were waiting since some time ago to Chrome 89 to be released
and, because of that, we had selenium pinned to 3.141.59-zinc
version (Chrome 79).

The cause for staying sticky was this issue:
    https://bugs.chromium.org/p/chromedriver/issues/detail?id=3682&q=&can=1&sort=-id

Chrome (and chromedriver) 89 have been released and Selenium has
already build the docker images for them:

https://github.com/SeleniumHQ/docker-selenium/releases/tag/3.141.59-20210311

So now we can unpin the old version and let the machinery to use the
latest versions available. That's what this PR does.