### PR TITLE
Revert "Disable accessibility (axe) with classic till MDL-70846 is fixed

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -795,22 +795,17 @@ then
     fi
   fi
 
-  AXE=""
-  # Accesibility tests disabled for classic until MDL-70846 is fixed.
-  if [ "${BEHAT_SUITE}" != "classic" ];
-  then
-    AXE="--axe"
-  fi
-
   echo php admin/tool/behat/cli/init.php \
-      ${BEHAT_INIT_SUITE} ${AXE} \
+      ${BEHAT_INIT_SUITE} \
+      --axe \
       -j="${BEHAT_TOTAL_RUNS}"
 
   docker exec -t "${WEBSERVER}" bash -c 'chown -R www-data:www-data /var/www/*'
 
   docker exec -t -u www-data "${WEBSERVER}" \
     php admin/tool/behat/cli/init.php \
-      ${BEHAT_INIT_SUITE} ${AXE} \
+      ${BEHAT_INIT_SUITE} \
+      --axe \
       -j="${BEHAT_TOTAL_RUNS}"
 else
   docker exec -t -u www-data "${WEBSERVER}" \


### PR DESCRIPTION
WARNING!! - Don't merge this yet, please!
WARNING!! - [MDL-70846](https://tracker.moodle.org/browse/MDL-70846) has been applied only to 311_STABLE and master and the problem is also present in 310_STABLE. We need to backport the fix before!

Now that the accessibility tests have been fixed by [MDL-70846](https://tracker.moodle.org/browse/MDL-70846), we can enabled them back @ CIs.

This reverts commit 6772ca686434a36ba1f318682d5083a4f0d2e7e6. (#48)

Closes #49