### PR TITLE
Pg10 bump

### DIFF
--- a/runner/master/pgsql.d/master.sh
+++ b/runner/master/pgsql.d/master.sh
@@ -42,7 +42,7 @@ wal_keep_segments = 32
 synchronous_standby_names = '${DBHOST_SLAVE}'
 
 #log_statement = 'all'
-log_directory = 'pg_log'
+log_directory = 'log'
 log_filename = 'postgres.log'
 logging_collector = on
 log_min_error_statement = error

--- a/runner/master/pgsql.d/slave.sh
+++ b/runner/master/pgsql.d/slave.sh
@@ -46,7 +46,7 @@ until psql -h ${DBHOST} -U moodle initial -c '\q'; do
 done
 
 echo "Restoring backup from master"
-pg_basebackup -h ${DBHOST} -U moodle -D "${PGDATA}" -P --xlog-method=stream
+pg_basebackup -h ${DBHOST} -U moodle -D "${PGDATA}" -P --wal-method=stream
 
 echo "Copying postgresql.conf in place"
 cp $PGDATA.orig/postgresql.conf $CONFFILE
@@ -56,7 +56,7 @@ echo "Configuring $CONFFILE as a slave"
 cat << EOF >> $CONFFILE
 hot_standby = on
 
-log_directory = 'pg_log'
+log_directory = 'log'
 log_filename = 'postgres.log'
 logging_collector = on
 log_min_error_statement = error

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -435,7 +435,7 @@ then
     -e DBNAME=$DBNAME \
     -v $SCRIPTPATH/pgsql.d:/docker-entrypoint-initdb.d \
     --tmpfs /var/lib/postgresql/data:rw \
-    postgres:9.6
+    postgres:10
 
   # Wait few sec, before executing commands.
   sleep 10
@@ -456,7 +456,7 @@ then
       -e DBNAME=$DBNAME \
       -v $SCRIPTPATH/pgsql.d:/docker-entrypoint-initdb.d \
       --tmpfs /var/lib/postgresql/data:rw \
-      postgres:9.6
+      postgres:10
 
     # Hack to make gosu work for all users on the slave.
     docker exec -u root $DBHOST_SLAVE bash -c 'chown root:postgres /usr/local/bin/gosu'


### PR DESCRIPTION
Bump to PG10 because it's going to be a requirement for Moodle 4.0 and up (see [MDL-70594](https://tracker.moodle.org/browse/MDL-70594)).

It comes with a few changes about replication stuff, following the information @ https://www.postgresql.org/docs/10/release-10.html
- rename functions, tools and options referencing "xlog" to "wal".
- log_directory changed from "pg_log" to "log".
    
Note that both:
- wal-method=stream
- log_directory=log
    
are default options so, extrictly speaking we shouldn't need to set them but it doesn't hurt to have them explicily defined, so keeping them.

Launching some jobs @ Ci...