### PR TITLE
Remove terminal from rerun commands

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -919,7 +919,7 @@ then
             --rerun)
 
           echo ${CMD[@]}
-          docker exec -t -u www-data "${WEBSERVER}" "${CMD[@]}"
+          docker exec -u www-data "${WEBSERVER}" "${CMD[@]}"
           NEWEXITCODE=$?
           if [ "$NEWEXITCODE" -eq 0 ]
           then
@@ -968,7 +968,7 @@ then
               --rerun)
 
             echo ${CMD[@]}
-            docker exec -t -u www-data "${WEBSERVER}" "${CMD[@]}"
+            docker exec -u www-data "${WEBSERVER}" "${CMD[@]}"
             if [ $? -ne 0 ]
             then
               NEWEXITCODE=$(($NEWEXITCODE + $status))


### PR DESCRIPTION
Hopefully this stops jobs where a step is undefined from holding things up on the rerun.