### PR TITLE
[runner] Switch to custom chromedriver image

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -617,6 +617,9 @@ then
   SELCHROMEIMAGE="selenium/standalone-chrome:${SELVERSION}"
   SELFIREFOXIMAGE="selenium/standalone-firefox:${SELVERSION}"
 
+  # Temporarily switching to custom image to include our bugfix for zero size failures.
+  SELCHROMEIMAGE="moodlehq/selenium-standalone-chrome:3.141.59-20210929-moodlehq"
+
   # Newer versions of Firefox do not allow Marionette to be disabled.
   # Version 47.0.1 is the latest version of Firefox we can support when Marionette is disabled.
   if [[ ${DISABLE_MARIONETTE} -ge 1 ]]


### PR DESCRIPTION
See https://tracker.moodle.org/browse/MDL-71108 for details on the
reasons behind this change, and its history.

This is a build with Chromedriver 94.0

I will provide an updated version in a few weeks once Chrome 95 is out, as I have an amd and arm version of this binary.