### PR TITLE
Don't start xvfb in headless runs

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -620,6 +620,11 @@ then
   echo "============================================================================"
 
   SHMMAP="--shm-size=2g"
+  XVFB=""
+  if [ -n "$BROWSER_HEADLESS" ] && [ "$BROWSER_HEADLESS" != "0" ]
+  then
+      XVFB="-e START_XVFB=false"
+  fi
 
   HASSELENIUM=1
   SELVERSION="3.141.59"
@@ -672,6 +677,7 @@ then
         --name ${SELITERNAME} \
         --detach \
         $SHMMAP \
+        $XVFB \
         -v "${CODEDIR}":/var/www/html \
         ${SELCHROMEIMAGE}
 
@@ -692,6 +698,7 @@ then
         --name ${SELITERNAME} \
         --detach \
         $SHMMAP \
+        $XVFB \
         -v "${CODEDIR}":/var/www/html \
         ${SELFIREFOXIMAGE}
 


### PR DESCRIPTION
It's not used and for sure will save some resources.

Differences are very subtle, just in logs you will see:

- For a headed run like [![Build Status](https://ci.moodle.org/buildStatus/icon?job=DEV.01+-+Developer-requested+Behat&build=17403)](https://ci.moodle.org/view/Testing/job/DEV.01%20-%20Developer-requested%20Behat/17403/), from console:
```
2021-10-23 14:21:22,625 INFO supervisord started with pid 8
2021-10-23 14:21:23,627 INFO spawned: 'xvfb' with pid 10
2021-10-23 14:21:23,628 INFO spawned: 'selenium-standalone' with pid 11
2021-10-23 14:21:23,755 INFO success: xvfb entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2021-10-23 14:21:23,755 INFO success: selenium-standalone entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
14:21:23.799 INFO [GridLauncherV3.lambda$buildLaunchers$3] - Launching a standalone Selenium Server on port 4444
```
- For a headless run like [![Build Status](https://ci.moodle.org/buildStatus/icon?job=DEV.01+-+Developer-requested+Behat&build=17404)](https://ci.moodle.org/view/Testing/job/DEV.01%20-%20Developer-requested%20Behat/17404/), from console:
```
2021-10-23 14:21:49,839 INFO supervisord started with pid 8
2021-10-23 14:21:50,842 INFO spawned: 'xvfb' with pid 10
2021-10-23 14:21:50,843 INFO spawned: 'selenium-standalone' with pid 11
2021-10-23 14:21:50,847 INFO success: xvfb entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2021-10-23 14:21:50,847 INFO success: selenium-standalone entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2021-10-23 14:21:50,847 INFO exited: xvfb (exit status 0; expected)
14:21:51.016 INFO [GridLauncherV3.lambda$buildLaunchers$3] - Launching a standalone Selenium Server on port 4444
```

The different line in headless runs is `INFO exited: xvfb (exit status 0; expected)` that confirms that the xvfb service is stopped immediately after having been started.

Let's allow the 2 jobs above to complete, just in case there is any timing difference. Note that, right now, we have 18 failures happening in headed runs, so it's possible for the headed run above to fail. That's ok, this issue is not about fixing any failure, only about keeping xvfb down if the run is headless.