### PR TITLE
Fix wrong BBB mock server container name

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -520,7 +520,7 @@ docker run \
 
 export BBBMOCKURL="http://${BBBMOCK}"
 echo BBBMOCKURL >> "${ENVIROPATH}"
-docker logs ${BBBMOCKURL}
+docker logs ${BBBMOCK}
 
 
 if [ "${TESTTORUN}" == "phpunit" ]


### PR DESCRIPTION
We were using the wrong container name when calling "docker logs" and getting errors during testing like "Error: No such container: http://bbbmock9145c76fb054c670"