### PR TITLE
[runner] Update to Chromedriver 96.0 custom

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -193,6 +193,9 @@ class moodlehq_ci_runner {
         // Set the default profile to use the first selenium URL only.
         $profile['wd_host'] = getenv('SELENIUMURL_1') . '/wd/hub';
 
+        // Work around for https://github.com/Behat/MinkExtension/issues/376.
+        $profile['capabilities']['marionette'] = true;
+
         $CFG->behat_profiles = [];
         $CFG->behat_profiles[$browser] = $profile;
 

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -634,7 +634,7 @@ then
   SELFIREFOXIMAGE="selenium/standalone-firefox:${SELVERSION}"
 
   # Temporarily switching to custom image to include our bugfix for zero size failures.
-  SELCHROMEIMAGE="moodlehq/selenium-standalone-chrome:3.141.59-20210929-moodlehq"
+  SELCHROMEIMAGE="moodlehq/selenium-standalone-chrome:96.0-moodlehq"
 
   # Newer versions of Firefox do not allow Marionette to be disabled.
   # Version 47.0.1 is the latest version of Firefox we can support when Marionette is disabled.


### PR DESCRIPTION
Switching to the 96.0 image of https://github.com/moodlehq/selenium-standalone-chrome

Note: Selenium no longer produce images for Selenium 3.141.59 so this image is based on Selenium 4.1!

Before: https://ci.moodle.org/view/Testing/job/DEV.01%20-%20Developer-requested%20Behat/18727/
After: https://ci.moodle.org/view/Testing/job/DEV.01%20-%20Developer-requested%20Behat/18796/

Just affected Scenarios:
Before: https://ci.moodle.org/view/Testing/job/DEV.01%20-%20Developer-requested%20Behat/18803
After: https://ci.moodle.org/view/Testing/job/DEV.01%20-%20Developer-requested%20Behat/18804