### PR TITLE
Revert "Don't start xvfb in headless runs"

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -620,11 +620,6 @@ then
   echo "============================================================================"
 
   SHMMAP="--shm-size=2g"
-  XVFB=""
-  if [ -n "$BROWSER_HEADLESS" ] && [ "$BROWSER_HEADLESS" != "0" ]
-  then
-      XVFB="-e START_XVFB=false"
-  fi
 
   HASSELENIUM=1
   SELVERSION="3.141.59"
@@ -677,7 +672,6 @@ then
         --name ${SELITERNAME} \
         --detach \
         $SHMMAP \
-        $XVFB \
         -v "${CODEDIR}":/var/www/html \
         ${SELCHROMEIMAGE}
 
@@ -698,7 +692,6 @@ then
         --name ${SELITERNAME} \
         --detach \
         $SHMMAP \
-        $XVFB \
         -v "${CODEDIR}":/var/www/html \
         ${SELFIREFOXIMAGE}
 


### PR DESCRIPTION
This reverts commit 520e91ee67cb27c5f9c6973c1c9997167b1942b2.

Immediately after applying #67 we have started to get all
headless jobs failing with all sort of timeouts and > 8h
of execution time. Headless runs.

And this is the only change that has been performed since
then, hence, reverting here and now.