### PR TITLE
Unpin MariaDB

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -345,7 +345,7 @@ then
       --tmpfs /var/lib/mysql:rw \
       -v $SCRIPTPATH/mysql.d/master/conf.d:/etc/mysql/conf.d \
       -v $SCRIPTPATH/mysql.d/master/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d \
-      mariadb:10.5
+      mariadb:10
 
     echo "Starting slave"
     docker run \
@@ -361,7 +361,7 @@ then
       -v $SCRIPTPATH/mysql.d/slave/config:/config \
       -v $SCRIPTPATH/mysql.d/slave/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d \
       --tmpfs /var/lib/mysql:rw \
-      mariadb:10.5
+      mariadb:10
 
     # Hack to make gosu work for all users on the slave.
     docker exec -u root $DBHOST_SLAVE bash -c 'chown root:mysql /usr/local/bin/gosu'
@@ -378,7 +378,7 @@ then
       -e MYSQL_PASSWORD="${DBPASS}" \
       --tmpfs /var/lib/mysql:rw \
       -v $SCRIPTPATH/mysql.d/standalone/conf.d:/etc/mysql/conf.d \
-      mariadb:10.5
+      mariadb:10
   fi
 
   export DBCOLLATION=utf8mb4_bin


### PR DESCRIPTION
Now that 10.6.7 and 10.7.3 have been releases and their
docker images are available, we can unpin it @ GHA.

Fixes #55