### PR TITLE
Enable lang install/upgrade tests only if lang upgrades are enabled

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -40,6 +40,13 @@ if ($slave = getenv('DBHOST_SLAVE')) {
 // Skip language upgrade during the on-sync period.
 $CFG->skiplangupgrade = true;
 
+// Enable tests needing language install/upgrade
+// only if we have language upgrades enabled (aka,
+// when we aren't skipping them).
+if (empty($CFG->skiplangupgrade)) {
+    define('TOOL_LANGIMPORT_REMOTE_TESTS', true);
+}
+
 $CFG->wwwroot   = 'http://host.name';
 $CFG->dataroot  = '/var/www/moodledata';
 $CFG->admin     = 'admin';


### PR DESCRIPTION
Over a few days/weeks after a major release, the lang upgrades
are disabled in testing infrastructure, because the new development
branch (4.1) in this case, doesn't exist yet.

When we proceed to disable the lang upgrades (part of the release
process) we need to ensure that all the tests using the languages
install/upgrade are skipped.

To do so, we don't define the TOOL_LANGIMPORT_REMOTE_TESTS constant
so all the related tests always will look for it to decide between
being executed or skipped.

In PHPUnit that's checked with code like:

    if (!defined('TOOL_LANGIMPORT_REMOTE_TESTS')) => skip

In Behat that's checked with the step:

    Given remote langimport tests are enabled

For more details, see https://tracker.moodle.org/browse/MDL-74512