### PR TITLE
For sqlsrv, switch from 2017-latest to latest

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -104,7 +104,7 @@ then
             DBTAG=5.7 # Because it's the master lowest supported version and we need it covered by default.
             ;;
         mssql | sqlsrv)
-            DBTAG=2017-latest # Because we havent't got newer versions to work yet.
+            DBTAG=latest # No pin, right now 2019-latest
             ;;
         oci)
             DBTAG=latest # No pin, right now this is 11.2


### PR DESCRIPTION
Note that, right now, "latest" is exactly 2017-latest, so everything will continue working exactly the same.

But once we finish with the tests @ MDLSITE-6045, we'll make 2019-latest to become "latest".

That's the reason the comment in the runner says
"right now 2019-latest", because in hours, if everything goes ok, 2019 will become the latest.