### PR TITLE
Limit the tmpfs usage and ensure no binlogs in standalone runs

### DIFF
--- a/runner/master/mariadb.d/standalone/conf.d/moodle.cnf
+++ b/runner/master/mariadb.d/standalone/conf.d/moodle.cnf
@@ -4,6 +4,8 @@ default-character-set = utf8mb4
 [mysqld]
 innodb_file_per_table = 1
 
+skip-log-bin
+
 character-set-server = utf8mb4
 collation-server = utf8mb4_bin
 skip-character-set-client-handshake

--- a/runner/master/mysql.d/standalone/conf.d/moodle.cnf
+++ b/runner/master/mysql.d/standalone/conf.d/moodle.cnf
@@ -4,6 +4,8 @@ default-character-set = utf8mb4
 [mysqld]
 innodb_file_per_table = 1
 
+skip-log-bin
+
 character-set-server = utf8mb4
 collation-server = utf8mb4_bin
 skip-character-set-client-handshake

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -349,7 +349,7 @@ then
       -e MYSQL_DATABASE="${DBNAME}" \
       -e MYSQL_USER="${DBUSER}" \
       -e MYSQL_PASSWORD="${DBPASS}" \
-      --tmpfs /var/lib/mysql:rw \
+      --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=1024m \
       -v $SCRIPTPATH/mysql.d/standalone/conf.d:/etc/mysql/conf.d \
       mysql:${DBTAG}
   fi
@@ -405,7 +405,7 @@ then
       -e MYSQL_DATABASE="${DBNAME}" \
       -e MYSQL_USER="${DBUSER}" \
       -e MYSQL_PASSWORD="${DBPASS}" \
-      --tmpfs /var/lib/mysql:rw \
+      --tmpfs /var/lib/mysql:rw,noexec,nosuid,size=1024m \
       -v $SCRIPTPATH/mariadb.d/standalone/conf.d:/etc/mysql/conf.d \
       mariadb:${DBTAG}
   fi
@@ -501,7 +501,7 @@ then
       -e POSTGRES_DB="${DBNAME}" \
       -e POSTGRES_USER=moodle \
       -e POSTGRES_PASSWORD=moodle \
-      --tmpfs /var/lib/postgresql/data:rw \
+      --tmpfs /var/lib/postgresql/data:rw,noexec,nosuid,size=1024m \
       -v $SCRIPTPATH/pgsql.d/standalone:/docker-entrypoint-initdb.d \
       postgres:${DBTAG}
   fi


### PR DESCRIPTION
With the switch to MySQL, bin logs are enabled by default and, for complete phpunit/behat runs they become huge, needing > 4Gb for completing.

While this was not affecting us in the CI infrastructure, because there are up to 32Gb available for tmpfs in the workers, we don't need those bin logs at all.

So this commit does:

1. Limit the tmpfs to be max 1Gb (latest tests are using ~300Mb).
2. Ensure that bin logs are disabled for mysql/mariadb runs.

Note that point 2 only affects to standalone runs, of course primary/replica runs do require the binary logs to be there so we aren't touching them now.

Surely they will be revisited when we try to fix existing #84. But that's another story...