### PR TITLE
Fix ${var} string interpolation

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -167,7 +167,7 @@ class moodlehq_ci_runner {
     ) {
         global $CFG;
 
-        $CFG->behat_wwwroot   = "http://${behathostname}";
+        $CFG->behat_wwwroot   = "http://{$behathostname}";
         $CFG->behat_dataroot  = '/var/www/behatdata/run';
         $CFG->behat_prefix = 'b_';
 


### PR DESCRIPTION
Since PHP 8.2, placing the dollar sign outside the curly brace is deprecated when the expression inside the braces resolves to a variable or an expression.