### PR TITLE
Configure imagick PHP extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You also need to set several environment variables, depending on your testing re
 | `MOBILE_VERSION`    | `latest`, `next`                                        | Empty               | The Moodle app version to use when executing behat @app tests. |
 | `PLUGINSTOINSTALL`  | gitrepoplugin1\|gitfolderplugin1\|gitbranchplugin1;gitrepoplugin2\|gitfolderplugin2         | Empty               | External plugins to install.<br/>The following information is needed for each plugin: gitrepo (mandatory), folder (mandatory) and branch (optional).<br/>The plugin fields should be separated by "\|" and each plugin should be separated using ";".<br/>Example: "https://github.com/moodlehq/moodle-local_mobile.git\|local/mobile\|MOODLE_37_STABLE;git@github.com:jleyva/moodle-block_configurablereports.git\|blocks/configurable_reports" |
 | `PLUGINSDIR`        | /path/to/your/plugins                                   | $WORKSPACE/plugins  | The location of the plugins checkout. |
+| `IMAGICK`           | 1                                                       | Empty               | Install the `imagick` PHP extension on the docker PHP container. |
 
 Other args are also available too, but are not recommended.
 

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -197,6 +197,7 @@ fi
 # Setup Environment
 UUID=$(uuid | sha1sum | awk '{print $1}')
 UUID=${UUID:0:16}
+IMAGICK=${IMAGICK:-}
 export DBHOST=database"${UUID}"
 export DBTYPE="${DBTYPE:-pgsql}"
 export DBTAG="${DBTAG:-latest}"
@@ -256,6 +257,7 @@ echo "== MOBILE_APP_PORT: ${MOBILE_APP_PORT}"
 echo "== MOBILE_VERSION: ${MOBILE_VERSION}"
 echo "== PLUGINSTOINSTALL: ${PLUGINSTOINSTALL}"
 echo "== TESTSUITE: ${TESTSUITE}"
+echo "== IMAGICK: ${IMAGICK}"
 echo "== Environment: ${ENVIROPATH}"
 echo "============================================================================"
 
@@ -785,6 +787,15 @@ docker run \
   -v "${COMPOSERCACHE}:/var/www/.composer:rw" \
   -v "${OUTPUTDIR}":/shared \
   ${PHP_SERVER_DOCKER}
+
+# Install imagick extension
+if [ -n "$IMAGICK" ];
+then
+    docker exec "${WEBSERVER}" apt-get update
+    docker exec "${WEBSERVER}" apt-get install -y libmagickwand-dev --no-install-recommends
+    docker exec "${WEBSERVER}" pecl install imagick
+    docker exec "${WEBSERVER}" docker-php-ext-enable imagick
+fi
 
 # Copy code in place.
 echo "== Copying code in place"


### PR DESCRIPTION
I'm trying to use my [local_behatsnapshots](https://github.com/NoelDeMartin/moodle-local_behatsnapshots/) plugin with the runner, and one of the issues I am facing is that it relies on having the `imagick` PHP extension installed.

In this PR, I just went the easy route and install it using a new env variable called `IMAGICK`. I can see how it isn't the best solution, but the others require more work and I wanted to hear about the integrators' opinion before moving forward.

The main problem I see with the current approach is that the extension is installed *after* the container is launched, which slows down the execution considerably. The ideal solution would be that the docker image already comes with the extension installed, but given that the image is widely used I don't think it'd make sense to add it out of the box (right?). Maybe the ideal solution would be to build another image, but that's more complicated than it seems if we want to keep it up to date. So I thought maybe we could add a new flavor such as `moodle-php-apache:${PHP_VERSION}-imagick` that's published automatically with every new update. I could also fork it and use `PHP_SERVER_DOCKER` to override the default image, but that'd make it harder to keep up to date. Any of those involves some work, so I wanted to ask before delving into it.

Another issue is what if we need more extensions in the future? Currently I just need this one, but I can see this potentially being an issue. It would be nice to come up with a generic solution to install extensions, but I'm not sure how to go about it. This could be a clear case of [YAGNI](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it) though, so I'm ok with just solving for `imagick`. But I thought I'd ask in case there's some obvious solution I'm missing.

What do you think, should I pursue some other route? Or can we move forward with this simple yet inefficient approach?