### PR TITLE
Support custom config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You also need to set several environment variables, depending on your testing re
 | `MOBILE_VERSION`    | `latest`, `next`                                        | Empty               | The Moodle app version to use when executing behat @app tests. |
 | `PLUGINSTOINSTALL`  | gitrepoplugin1\|gitfolderplugin1\|gitbranchplugin1;gitrepoplugin2\|gitfolderplugin2         | Empty               | External plugins to install.<br/>The following information is needed for each plugin: gitrepo (mandatory), folder (mandatory) and branch (optional).<br/>The plugin fields should be separated by "\|" and each plugin should be separated using ";".<br/>Example: "https://github.com/moodlehq/moodle-local_mobile.git\|local/mobile\|MOODLE_37_STABLE;git@github.com:jleyva/moodle-block_configurablereports.git\|blocks/configurable_reports" |
 | `PLUGINSDIR`        | /path/to/your/plugins                                   | $WORKSPACE/plugins  | The location of the plugins checkout. |
+| `MOODLE_CONFIG`     | JSON STRING                                             | Empty               | Custom moodle config to use during the execution. For example, if you want to set `$CFG->noreplyaddress = 'campus@example.com';`, the value of this variable should be `{"noreplyaddress":"campus@example.com"}`. |
 
 Other args are also available too, but are not recommended.
 

--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -182,6 +182,21 @@ class moodlehq_ci_runner {
         if ($timeoutfactor) {
             $CFG->behat_increasetimeout = $timeoutfactor;
         }
+
+        self::configure_overrides();
+    }
+
+    /**
+     * Override configuration values.
+     */
+    public static function configure_overrides() {
+        global $CFG;
+
+        $overrides = json_decode(getenv('MOODLE_CONFIG') ?: '{}', true);
+
+        foreach ($overrides as $key => $value) {
+            $CFG->{$key} = $value;
+        }
     }
 
     /**

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -205,6 +205,7 @@ export DBPASS="${DBPASS:-moodle}"
 export DBHOST="${DBHOST:-${DBTYPE}}"
 export DBHOST_SLAVE=""
 export DBNAME="moodle"
+export MOODLE_CONFIG=${MOODLE_CONFIG:-}
 
 echo "DBTYPE" >> "${ENVIROPATH}"
 echo "DBTAG" >> "${ENVIROPATH}"
@@ -225,6 +226,7 @@ echo "BEHAT_TIMING_FILENAME" >> "${ENVIROPATH}"
 echo "BEHAT_INCREASE_TIMEOUT" >> "${ENVIROPATH}"
 echo "DISABLE_MARIONETTE" >> "${ENVIROPATH}"
 echo "MLBACKEND_PYTHON_VERSION" >> "${ENVIROPATH}"
+echo "MOODLE_CONFIG" >> "${ENVIROPATH}"
 
 echo "============================================================================"
 echo "= Job summary <<<"
@@ -256,6 +258,7 @@ echo "== MOBILE_APP_PORT: ${MOBILE_APP_PORT}"
 echo "== MOBILE_VERSION: ${MOBILE_VERSION}"
 echo "== PLUGINSTOINSTALL: ${PLUGINSTOINSTALL}"
 echo "== TESTSUITE: ${TESTSUITE}"
+echo "== MOODLE_CONFIG: ${MOODLE_CONFIG}"
 echo "== Environment: ${ENVIROPATH}"
 echo "============================================================================"
 


### PR DESCRIPTION
I'm trying to use my [local_behatsnapshots](https://github.com/NoelDeMartin/moodle-local_behatsnapshots/) plugin with the runner, and one of the issues I am facing is that I need to set some custom config values.

I could have solved this by adding a new variable and setting it manually like we're already doing with others (like `DBTYPE`, `BEHAT_INCREASE_TIMEOUT`, etc.). But I think that's not the best approach for a couple of reasons.

First, I'm not sure if I want to hard-code my plugin's config names. I'm still working on it and I may want to change the naming. I also don't like the idea of coupling this repository to my plugin which is a bit experimental.

And second, I've faced similar problems in the past that I think could be solved using this. For example, [MDL-74293](https://tracker.moodle.org/browse/MDL-74293).

In any case, if you don't like the idea I can open a new PR just adding a new env variable to set the config for my plugin.