### PR TITLE
Update runner to support Matrix mock server

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -131,15 +131,20 @@ if (!empty(getenv('EXTTESTURL'))) {
     define('TEST_EXTERNAL_FILES_HTTPS_URL', getenv('EXTTESTURL'));
 }
 
-if (!empty(getenv('BBBMOCKURL'))) {
-    if (property_exists($CFG, 'behat_wwwroot')) {
-        $mockhash = sha1($CFG->behat_wwwroot);
-    } else {
-        $mockhash = sha1($CFG->wwwroot);
-    }
+if (property_exists($CFG, 'behat_wwwroot')) {
+    $mockhash = sha1($CFG->behat_wwwroot);
+} else {
+    $mockhash = sha1($CFG->wwwroot);
+}
 
+if (!empty(getenv('BBBMOCKURL'))) {
     $bbbmockurl = getenv('BBBMOCKURL') . "/hash{$mockhash}";
     define("TEST_MOD_BIGBLUEBUTTONBN_MOCK_SERVER", $bbbmockurl);
+}
+
+if (!empty(getenv('MATRIXMOCKURL'))) {
+    $matrixmockurl = getenv('MATRIXMOCKURL') . "/hash{$mockhash}";
+    define("TEST_COMMUNICATION_MATRIX_MOCK_SERVER", $matrixmockurl);
 }
 
 if ($mlbackendpython = getenv('MLBACKENDTESTNAME')) {

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -568,6 +568,17 @@ export BBBMOCKURL="http://${BBBMOCK}"
 echo BBBMOCKURL >> "${ENVIROPATH}"
 docker logs ${BBBMOCK}
 
+MATRIXMOCK=matrixmock"${UUID}"
+docker run \
+  --detach \
+  --name ${MATRIXMOCK} \
+  --network "${NETWORK}" \
+  moodlehq/matrixsynapse_mock:latest
+
+export MATRIXMOCKURL="http://${MATRIXMOCK}"
+echo MATRIXMOCKURL >> "${ENVIROPATH}"
+docker logs ${MATRIXMOCK}
+
 if [ "${TESTTORUN}" == "phpunit" ]
 then
   EXTTESTNAME=exttests"${UUID}"


### PR DESCRIPTION
In Moodle LMS 4.2 we will have support to connect to a Matrix instance. This patch adds support for the Matrix mock server we have developed. The mock server is required for unit and behat tests.

This mock has been implemented using the same stack (Symfony, Docker) as the existing BBB mock.

