### PR TITLE
Remove axe option from behat init

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -876,7 +876,6 @@ then
 
   echo php admin/tool/behat/cli/init.php \
       ${BEHAT_INIT_SUITE} \
-      --axe \
       -j="${BEHAT_TOTAL_RUNS}"
 
   docker exec -t "${WEBSERVER}" bash -c 'chown -R www-data:www-data /var/www/*'
@@ -884,7 +883,6 @@ then
   docker exec -t -u www-data "${WEBSERVER}" \
     php admin/tool/behat/cli/init.php \
       ${BEHAT_INIT_SUITE} \
-      --axe \
       -j="${BEHAT_TOTAL_RUNS}"
 else
   docker exec -t -u www-data "${WEBSERVER}" \


### PR DESCRIPTION
After MDL-77733 axe accessibility tests are enabled by default.

This should be put on hold until the MDL above gets integrated into moodle core.