### PR TITLE
Ensure that behatrunXX sof links are created with www-data

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -1025,7 +1025,7 @@ then
             echo ">>> startsection Running behat again (rerun #${RERUN}) for failed steps on process ${RUN} <<<"
             echo "============================================================================"
 
-            docker exec -t -w /var/www/html "${WEBSERVER}" bash -c \
+            docker exec -t -w /var/www/html -u www-data "${WEBSERVER}" bash -c \
               "if [ ! -L \"behatrun${RUN}\" ]; then ln -s . \"behatrun${RUN}\"; fi"
 
             CMD=(vendor/bin/behat


### PR DESCRIPTION
Recent changes to the upstream php-apache images now require us to explicitly create the behatrunXX sof links with the www-data user (previously it was ok with root too).

See https://github.com/docker-library/php/issues/1393

In fact we already were using the --user (-u) flag in a number of cmds, just the links command were missing them and causing behat reruns to stop working.

Once this is merged, we'll proceed to unpin the php-apache images @ https://github.com/moodlehq/moodle-php-apache/issues/174