### PR TITLE
Update chromeOptions for headless

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -251,7 +251,7 @@ class moodlehq_ci_runner {
             'capabilities' => [
                 'browserName' => 'chrome',
                 'extra_capabilities' => [
-                    'chromeOptions' => [
+                    'goog:chromeOptions' => [
                         'args' => [
                             // Disable the sandbox.
                             // https://peter.sh/experiments/chromium-command-line-switches/#no-sandbox
@@ -289,9 +289,11 @@ class moodlehq_ci_runner {
                     // https://chromedriver.chromium.org/capabilities
                     'capabilities' => [
                         'extra_capabilities' => [
-                            'chromeOptions' => [
+                            'goog:chromeOptions' => [
                                 'args' => [
-                                    'headless',
+                                    // Headless mode is going away with new Selenium versions and Chrome.
+                                    // This is backwards compatinble with older versions of Selenium.
+                                    'headless=new',
                                 ],
                             ],
                         ],


### PR DESCRIPTION
Browser options are passed into the browser via the capabilities.extra_capabilities dictionary, which is passed into Selenium, and into the relevant driver, andn finally to the browser.

Prior to the W3C driver, the JSONWire protocol was very loose on definition. Chrome accepted options via `chromeOptions`, but with the advent of the W3C protocol, these extensions to the driver must be namespaced with the implementation. See
https://www.w3.org/TR/webdriver/#extensions-0 for the details.

Essentially this means that, instead of:

    chromeOptions

We must instead have:

    goog:chromeOptions

We've been using W3C browsers for some time, and they've been respecting _both_ options til now.

Since Selenium 4.8.0, support for the non-W3C compatible extensions is dropped.

Alongside this, Chrome has also updated its headless argument from

    --headless

to

    --headless=new