### PR TITLE
Add the git commit and the moodle branch to the summary

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -71,6 +71,12 @@ fi
 export PHP_VERSION="${PHP_VERSION:-7.1}"
 export PHP_SERVER_DOCKER="${PHP_SERVER_DOCKER:-moodlehq/moodle-php-apache:${PHP_VERSION}}"
 
+# If available, which commit hash is being tested.
+export GIT_COMMIT="N/A"
+if [ -d "${CODEDIR}"/.git ]; then
+    export GIT_COMMIT=$(cd "${CODEDIR}" && git rev-parse HEAD)
+fi
+
 # Which Moodle version (XY) is being used.
 export MOODLE_VERSION=$(grep "\$branch" "${CODEDIR}"/version.php | sed "s/';.*//" | sed "s/^\$.*'//")
 # Which Mobile app version is used: latest (stable), next (master), x.y.z.
@@ -242,7 +248,9 @@ echo "== Build Id: ${BUILD_ID}"
 echo "== Output directory: ${OUTPUTDIR}"
 echo "== UUID: ${UUID}"
 echo "== Container prefix: ${UUID}"
-echo "== PHP Version: ${PHP_VERSION}"
+echo "== GIT commit: ${GIT_COMMIT}"
+echo "== PHP version: ${PHP_VERSION}"
+echo "== Moodle branch (version.php): ${MOODLE_VERSION}"
 echo "== DBTORUN: ${DBTORUN}"
 echo "== DBTYPE: ${DBTYPE}"
 echo "== DBTAG: ${DBTAG}"


### PR DESCRIPTION
For some post-processing that I'm doing (and in general)
it can be interesting to have these 2 pieces of information
in the summary section of the runner output:

- Moodle version.php $branch (39, 400, 401, 402, 403...)
- Current HEAD being tested (when available).

The output will be something like:

```
============================================================================
= Job summary <<<
============================================================================
== Workspace: /tmp/ws
== Build Id: cirunner
== Output directory: /tmp/ws/cirunner
== UUID: 83508e56fd34c8a8
== Container prefix: 83508e56fd34c8a8
== GIT commit: 4ed782dd03a73d5a9ed2a5b6d6548b95c28cb59a
== PHP version: 8.0
== Moodle branch (version.php): 403
== DBTORUN:
== DBTYPE: pgsql
...
```

I've tested it locally, both with a git clone and a non-git codebase and it seems to work ok.