### PR TITLE
Add missing assignment of latest exit code

### DIFF
--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -1021,6 +1021,7 @@ then
           echo ${CMD[@]}
           docker exec -u www-data "${WEBSERVER}" "${CMD[@]}"
           NEWEXITCODE=$?
+          EXITCODE=$NEWEXITCODE
           if [ "$NEWEXITCODE" -eq 0 ]
           then
             break;


### PR DESCRIPTION
This was causing parallel = 1 runs to end with error whenever the reruns had passed all the tests remaining (because the original EXITCODE variable, that failed in the initial run was not being updated ever.

You can see that, some lines below, for parallel > 1 runs, that are the ones we normally do @ CIs the very same assignment is done, and because of that we had not detected this problem that only affects to parallel = 1.

With this change, we are feeding EXITCODE correctly for them.

For an example of the problem, see:

https://ci.moodle.org/view/Testing/job/DEV.01%20-%20Developer-requested%20Behat/38163/

It shows how, on rerun #2, all the tests are already passing ok (so there isn't any need to do rerun #3), and, still, the final outcome of the job is error, when it should be passed.

Once this gets merged, I'll rerun that build to verify that the fix really fixes it.

Ciao :-)