### PR TITLE
Preparing for the switch from goutte to browserkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You also need to set several environment variables, depending on your testing re
 | `TESTTORUN`         | `phpunit` or `behat`                                    | `phpunit`           | Used to determine which test will be run. |
 | `TAGS`              | A behat tag arg, or phpunit filter                      | Optional            | The tag argument to behat, or a valid argument to the phpunit `--filter`. |
 | `NAME`              | A behat name arg. Ignored for phpunit                   | Optional            | The name argument to behat. It will be ignored for phpunit. |
-| `BROWSER`           | `firefox`, `chrome`, `goutte`                           | `chrome`            | The browser to use for behat tests. |
+| `BROWSER`           | `firefox`, `chrome`, `browserkit`, `goutte` (deprecated)| `chrome`            | The browser to use for behat tests. |
 | `BROWSER_DEBUG`     | 1                                                       | Empty               | Increase verbosity for browsers which support this |
 | `BROWSER_HEADLESS`  | 1                                                       | Empty               | Run the browser in headless mode |
 | `BEHAT_TOTAL_RUNS`  | INTEGER                                                 | 3                   | For behat, the number of parallel runs to perform. |

--- a/runner/master/run.sh
+++ b/runner/master/run.sh
@@ -783,7 +783,7 @@ then
 
       ITER=$(($ITER+1))
     done
-  elif [ "$BROWSER" == "goutte" ]
+  elif [ "$BROWSER" == "goutte" ] || [ "$BROWSER" == "browserkit" ]
   then
       export BROWSER=""
       HASSELENIUM=0


### PR DESCRIPTION
Soon (MDL to created) we may be moving from Goutte (that has been abandoned/archived) to BrowserKit.

These are the only places where we use goutte, aka the only required changes to keep the new "browserkit" working the same:
- README.md
- browser to decide not to start the selenium containers.

Trivial.