### PR TITLE
MR3: Disable lang upgrades until lang packs are available (4.3)

### DIFF
--- a/runner/master/config.template.php
+++ b/runner/master/config.template.php
@@ -49,7 +49,7 @@ if (getenv('DBTYPE') === 'sqlsrv') {
 }
 
 // Skip language upgrade during the on-sync period.
-$CFG->skiplangupgrade = false;
+$CFG->skiplangupgrade = true;
 
 // Enable tests needing language install/upgrade
 // only if we have language upgrades enabled (aka,


### PR DESCRIPTION
Part of the 4.3 release process. This will be merged during the [4.3 packaging](https://moodledev.io/general/development/process/release#packaging).