### PR TITLE
Bump Redis to version 5

### DIFF
--- a/runner/main/modules/docker-caches/docker-caches.sh
+++ b/runner/main/modules/docker-caches/docker-caches.sh
@@ -58,7 +58,7 @@ function docker-caches_setup() {
         --detach \
         --name "${REDISTESTNAME}" \
         --network "${NETWORK}" \
-    redis:3
+    redis:5
     echo "Redis URL: ${REDISTESTNAME}"
     echo "Redis logs:"
     docker logs "${REDISTESTNAME}"


### PR DESCRIPTION
MDL-66151 required Redis 5.0.0. We need to bump Redis from 3 to 5