### PR TITLE
MR3: Disable lang upgrades until lang packs are available (4.5)

### DIFF
--- a/runner/main/modules/docker-php/config.template.php
+++ b/runner/main/modules/docker-php/config.template.php
@@ -49,7 +49,7 @@ if (getenv('DBTYPE') === 'sqlsrv') {
 }
 
 // Skip language upgrade during the on-sync period.
-$CFG->skiplangupgrade = false;
+$CFG->skiplangupgrade = true;
 
 // Enable tests needing language install/upgrade
 // only if we have language upgrades enabled (aka,


### PR DESCRIPTION
Part of the 4.5 release process. This will be merged during the [4.5 packaging](https://moodledev.io/general/development/process/release#packaging)