### PR TITLE
Use `caching_sha2_password` authentication plugin

### DIFF
--- a/runner/main/modules/docker-database/mysqli.d/primary/docker-entrypoint-initdb.d/01_privileges.sql
+++ b/runner/main/modules/docker-database/mysqli.d/primary/docker-entrypoint-initdb.d/01_privileges.sql
@@ -1,4 +1,4 @@
-CREATE USER 'replication'@'%' IDENTIFIED WITH mysql_native_password BY 'replication';
+CREATE USER 'replication'@'%' IDENTIFIED WITH caching_sha2_password BY 'replication';
 GRANT REPLICATION SLAVE ON *.* TO 'replication'@'%';
 
 ALTER USER 'root'@'%' IDENTIFIED BY 'moodle';


### PR DESCRIPTION
`mysql_native_password` is now disabled by default in 8.4 and removed in 9.0. So, it's better to use the new default authentication plugin which is `caching_sha2_password`