### PR TITLE
Remove verbosity on phpunit runs

### DIFF
--- a/runner/main/jobtypes/phpunit/phpunit.sh
+++ b/runner/main/jobtypes/phpunit/phpunit.sh
@@ -263,7 +263,6 @@ function phpunit_runcmd() {
         --disallow-test-output
         --fail-on-risky
         --log-junit /shared/log.junit
-        --verbose
     )
     if [[ -n "${PHPUNIT_FILTER}" ]]; then
         cmd+=(--filter "${PHPUNIT_FILTER}")


### PR DESCRIPTION
I looked at doing this by PHPUnit version but it is non-trivial and I feel pointless. There is no direct replacement for this in PHPUnit and it only really shows things like skipped tests, which we have turned off in other environments.