### PR TITLE
Switch from seleniarm to selenium for arm64 architecture

### DIFF
--- a/runner/main/modules/docker-selenium/docker-selenium.sh
+++ b/runner/main/modules/docker-selenium/docker-selenium.sh
@@ -106,16 +106,14 @@ function docker-selenium_setup() {
     fi
 
     # Only for testing purposes, we are going to introduce basic support for arm64 architecture.
-    # Many of the docker images already are multi-arch, but not the selenium ones, that are using
-    # a different repository for arm64. Let's use them here.
     # Important note: While we are still running Selenium 3, the arm64 images are using Selenium 4,
     # so they could come with new problems or incompatibilities.
     # As said, this is only for testing purposes, we are not going to support arm64 officially yet.
     # TODO: After testing, consider if we can make this the default for arm64, deleting this conf.
     # and using the seleniarm images when `uname -m` is arm64 or aarch64.
     if [[ -n ${TRY_SELENIARM} ]]; then
-        chromeimage="seleniarm/standalone-chromium:latest"
-        firefoximage="sseleniarm/standalone-firefox:latest"
+        chromeimage="selenium/standalone-chromium:latest"
+        firefoximage="selenium/standalone-firefox:latest"
     fi
 
     # And these are the final images and options we will use.


### PR DESCRIPTION
The seleniarm fork has now been merged into the main selenium project, so the seleniarm project has been archived and is gradually getting more and more out of date.

This change is just to switch to pulling the images from the main selenium repository since they now support arm64 architecture.

(Also, there's a typo in the name for the firefox image, so I'm not sure anyone else is using this anyway)