### PR TITLE
Remove E_STRICT usage in config.template.php

### DIFF
--- a/runner/main/modules/docker-php/config.template.php
+++ b/runner/main/modules/docker-php/config.template.php
@@ -57,7 +57,7 @@ $CFG->admin     = 'admin';
 $CFG->directorypermissions = 0777;
 
 // Debug options - possible to be controlled by flag in future..
-$CFG->debug = (E_ALL | E_STRICT); // DEBUG_DEVELOPER
+$CFG->debug = E_ALL; // DEBUG_DEVELOPER
 $CFG->debugdisplay = 1;
 $CFG->debugstringids = 1; // Add strings=1 to url to get string ids.
 $CFG->perfdebug = 15;


### PR DESCRIPTION
https://php.watch/versions/8.4/E_STRICT-deprecated

E_STRICT has been deprecated. Since PHP 8.0 all E_STRICT notices have been converted to E_NOTICE.