### PR TITLE
Pin Ubuntu to 22.04 for code coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
     if: github.repository == 'moodlehq/moodle-ci-runner'
     name: Code coverage
     needs: collect
-    runs-on: ubuntu-latest
+    # Ubuntu 24.04 is missing the kcov package. We can switch back to ubuntu-latest, once it points to 26.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Ubuntu 24.04 is missing the kcov package. We can pin Ubuntu to 22.04 at the moment