### PR TITLE
Add jest job

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# AGENTS.md — Moodle CI Runner
+
+## Architecture Overview
+
+This is a **Bash-based CI orchestrator** that runs PHPUnit and Behat tests for Moodle inside Docker containers. It uses a `jobs → modules → stages` model:
+
+- **Jobs** (`runner/main/jobtypes/`): Top-level test types (`phpunit`, `behat`, `postjobs`, `performance`). Each declares which modules it needs and in what order, then implements `_run`.
+- **Modules** (`runner/main/modules/`): Reusable units (e.g., `docker`, `docker-php`, `docker-database`, `env`, `git`, `browser`). Like mini-jobs but without `_run` or `_modules`.
+- **Stages**: Executed in fixed order by `runner/main/lib.sh`: `env+check → config → setup → run → teardown` (teardown runs in reverse module order).
+
+**Canonical code lives in `runner/main/`.** All other numbered directories (`runner/31/`, `runner/400/`, etc.) are exact copies kept for historical/version-mapping purposes — only ever edit `runner/main/`.
+
+## Function Naming Convention
+
+Every job/module uses its name as a prefix for all stage functions. A job named `phpunit` implements:
+
+| Function | Required | Purpose |
+|---|---|---|
+| `phpunit_env` | ✅ | Declare owned env variables (must include `EXITCODE`) |
+| `phpunit_check` | ✅ | Assert dependencies via `verify_modules`, `verify_env`, `verify_utilities` |
+| `phpunit_modules` | ✅ (jobs only) | Return ordered list of required modules |
+| `phpunit_run` | ✅ (jobs only) | Main execution; always sets `EXITCODE` |
+| `phpunit_config` | If has env vars | Set defaults; no instantiation here |
+| `phpunit_setup` | Optional | Instantiate artefacts; no config logic here |
+| `phpunit_teardown` | Optional | Cleanup; runs after `_run` via trap |
+| `phpunit_to_env_file` | Optional | Variables to write to Docker env file |
+| `phpunit_to_summary` | Optional | Variables to print in run summary |
+
+Modules follow the same API **except** they have no `_run` or `_modules` functions.
+
+Module names with hyphens (e.g., `docker-php`) use the hyphen in function names too: `docker-php_env()`.
+
+## Adding a New Job or Module
+
+1. Create `runner/main/jobtypes/<name>/<name>.sh` (job) or `runner/main/modules/<name>/<name>.sh` (module).
+2. Implement all required functions with the name prefix.
+3. For a new job: add it to the `_modules()` list of any job that needs it; reference `test/fixtures/jobtypes/dummy/dummy.sh` as a minimal job template.
+4. Add a corresponding `test/<name>_test.bats` file.
+
+## Key Runtime Variables
+
+| Variable | Set by | Purpose |
+|---|---|---|
+| `UUID` | `run.sh` | 16-char hex suffix on all Docker container names for isolation |
+| `SHAREDDIR` | `run.sh` | `$WORKSPACE/$BUILD_ID` — mounted as `/shared` in containers |
+| `ENVIROPATH` | `env` module | Env file passed to containers via `--env-file` |
+| `WEBSERVER` | `docker-php` module | Container name for the PHP/Apache container |
+| `EXITCODE` | Each job | Accumulated exit code; runner exits with this value |
+| `MOODLE_BRANCH` | `moodle-branch` module | Parsed from `version.php` in `CODEDIR` |
+
+Variables passed to containers are declared in the job's `_to_env_file()` function; the `env` module writes them to `ENVIROPATH` during setup.
+
+## Running Tests Locally
+
+Tests use [Bats](https://github.com/bats-core/bats-core) and require a separate Moodle checkout:
+
+```bash
+export MOODLE_CI_RUNNER_GITDIR=/path/to/moodle.git  # must have full history (fetch-depth: 0)
+bats test/runner_test.bats        # runner/orchestration tests
+bats test/phpunit_test.bats       # PHPUnit job integration tests
+bats test/behat_test.bats         # Behat job integration tests
+```
+
+Tests perform **destructive git checkouts** on `MOODLE_CI_RUNNER_GITDIR` — always use a dedicated clone. The `_common_teardown` helper resets it to `main` after each test.
+
+The `dummy` job type in `test/fixtures/jobtypes/dummy/` is installed/removed per test suite in `runner_test.bats` — it's the minimal reference for a working job.
+
+## Running Moodle Tests
+
+```bash
+export CODEDIR=/path/to/workspace/moodle
+export JOBTYPE=phpunit   # or behat
+export DBTYPE=pgsql
+export PHP_VERSION=8.3
+./runner/main/run.sh
+```
+
+Deprecated variable names (`TESTTORUN`, `TAGS`, `TESTSUITE`, `DBSLAVES`, etc.) still work but emit warnings. Use the current names listed in `README.md`.
+
+## Module Dependency Rules
+
+- A module can only use `verify_modules` to assert earlier modules are loaded — it cannot request new modules.
+- Module ordering in a job's `_modules()` list is a hard dependency contract: `docker` must precede `docker-php`; `env` must precede anything using `ENVIROPATH`; `docker-summary` must be last among docker modules.
+- `_config` functions must not instantiate resources; `_setup` functions must not set config defaults. This separation is enforced by code review convention.
+
+## Docker Container Lifecycle
+
+All containers share a Docker network (`NETWORK`, default `moodle`) and are named `<role><UUID>` (e.g., `webserver<UUID>`, `pgsql<UUID>`). The `docker` module's `_teardown` stops and removes all containers matching `UUID`. The `docker-php` module mounts `SHAREDDIR` as `/shared` and `COMPOSERCACHE` as `/var/www/.composer`.
+

--- a/runner/main/jobtypes/jest/jest.sh
+++ b/runner/main/jobtypes/jest/jest.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Moodle Continuous Integration Project.
+#
+# Moodle is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Moodle is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+# Jest job type functions.
+
+# Jest needed variables to go to the env file.
+# The Node.js container does not need a PHP/database env file, so this is empty.
+function jest_to_env_file() {
+    local env=()
+    echo "${env[@]}"
+}
+
+# This job type defines the following env variables
+function jest_env() {
+    env=(
+        JEST_FILTER
+        EXITCODE
+    )
+    echo "${env[@]}"
+}
+
+# Jest needed modules. Note that the order is important.
+# No docker-php, docker-database, moodle-core-copy or summary needed —
+# Jest is a pure JavaScript test runner that only requires Node.js.
+function jest_modules() {
+    local modules=(
+        env
+        moodle-branch
+        docker
+        docker-logs
+        git
+        docker-node
+        docker-healthy
+        docker-summary
+    )
+    echo "${modules[@]}"
+}
+
+# Jest job type checks.
+function jest_check() {
+    # Check all module dependencies.
+    verify_modules $(jest_modules)
+
+    # These env variables must be set for the job to work.
+    verify_env UUID NODESERVER
+}
+
+# Jest job type config.
+function jest_config() {
+    # Apply some defaults.
+    JEST_FILTER="${JEST_FILTER:-}"
+    EXITCODE=0
+}
+
+# Jest job type setup.
+function jest_setup() {
+    # Print the run summary (replaces the summary module, which requires docker-php).
+    echo "============================================================================"
+    echo "= Jest Job summary <<<"
+    echo "============================================================================"
+    echo "== JOBTYPE: ${JOBTYPE}"
+    echo "== Build Id: ${BUILD_ID}"
+    echo "== Code directory: ${CODEDIR}"
+    echo "== Shared directory: ${SHAREDDIR}"
+    echo "== UUID / Container suffix: ${UUID}"
+    echo "== GIT commit: ${GIT_COMMIT}"
+    echo "== Moodle branch (version.php): ${MOODLE_BRANCH}"
+    echo "== Node version: ${NODE_VERSION}"
+    echo "== JEST_FILTER: ${JEST_FILTER}"
+    echo "============================================================================"
+
+    # Copy the Moodle source code into the Node.js container.
+    echo
+    echo ">>> startsection Copying source files into Node.js container at $(date) <<<"
+    echo "============================================================================"
+    docker cp "${CODEDIR}"/. "${NODESERVER}":/app
+    echo "============================================================================"
+    echo ">>> stopsection <<<"
+
+    # Install Node.js dependencies.
+    echo
+    echo ">>> startsection Initialising Jest environment at $(date) <<<"
+    echo "============================================================================"
+    docker exec -t "${NODESERVER}" npm install
+    echo "============================================================================"
+    echo ">>> stopsection <<<"
+}
+
+# Jest job type run.
+function jest_run() {
+    echo
+    echo ">>> startsection Starting Jest run at $(date) <<<"
+    echo "============================================================================"
+
+    # Build the complete command.
+    local runcmd
+    jest_runcmd runcmd # By nameref.
+
+    echo "Running: ${runcmd[*]}"
+    echo
+
+    docker exec -t "${NODESERVER}" "${runcmd[@]}"
+    EXITCODE=$?
+
+    echo "============================================================================"
+    echo ">>> stopsection <<<"
+}
+
+# Returns (by nameref) an array with the command needed to run the Jest tests.
+function jest_runcmd() {
+    local -n cmd=$1
+    cmd=(npm test)
+    if [[ -n "${JEST_FILTER}" ]]; then
+        cmd+=(-- --passWithNoTests "${JEST_FILTER}")
+    fi
+}

--- a/runner/main/modules/docker-logs/docker-logs.sh
+++ b/runner/main/modules/docker-logs/docker-logs.sh
@@ -47,8 +47,8 @@ function docker-logs_teardown() {
     done
 
 # TODO: Why do we need this?
-# Only if the container exists and is running.
-if [[ -n $(docker ps --filter name="${WEBSERVER}" --filter status=running --quiet) ]]; then
+# Only if the container exists and is running (WEBSERVER may not be set for all job types).
+if [[ -n "${WEBSERVER:-}" ]] && [[ -n $(docker ps --filter name="${WEBSERVER}" --filter status=running --quiet) ]]; then
     docker exec -t "${WEBSERVER}" \
         chown -R "${UID}:${GROUPS[0]}" /shared
 fi

--- a/runner/main/modules/docker-node/docker-node.sh
+++ b/runner/main/modules/docker-node/docker-node.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Moodle Continuous Integration Project.
+#
+# Moodle is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Moodle is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+# Docker Node.js module functions.
+
+# This module defines the following env variables.
+function docker-node_env() {
+    env=(
+        NODE_VERSION
+        DOCKER_NODE
+        NODESERVER
+    )
+    echo "${env[@]}"
+}
+
+# Docker Node module checks.
+function docker-node_check() {
+    # Check all module dependencies.
+    verify_modules docker env
+
+    # These env variables must be set for the module to work.
+    verify_env NETWORK UUID SHAREDDIR
+}
+
+# Docker Node module config.
+function docker-node_config() {
+    # Apply some defaults.
+    NODE_VERSION="${NODE_VERSION:-22}"
+    DOCKER_NODE="${DOCKER_NODE:-node:${NODE_VERSION}}"
+    NODESERVER="nodeserver${UUID}"
+}
+
+# Docker Node module setup, start the Node.js container.
+function docker-node_setup() {
+    echo ">>> startsection Starting Node.js container <<<"
+    echo "============================================================================"
+
+    docker run \
+      --network "${NETWORK}" \
+      --name "${NODESERVER}" \
+      --detach \
+      --workdir /app \
+      -v "${SHAREDDIR}":/shared \
+      "${DOCKER_NODE}" \
+      tail -f /dev/null
+
+    echo
+    echo "Node.js container logs:"
+    docker logs "${NODESERVER}"
+    echo "============================================================================"
+    echo ">>> stopsection <<<"
+}
+

--- a/test/jest_test.bats
+++ b/test/jest_test.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# This file is part of the Moodle Continuous Integration Project.
+#
+# Moodle is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Moodle is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+# Run the tests for the jest job type.
+
+setup() {
+    load 'helpers/common'
+    _common_setup
+}
+
+teardown() {
+    load 'helpers/common'
+    _common_teardown
+}
+
+@test "Jest tests: run the job for main" {
+    # Set all the required variables.
+    JOBTYPE="jest"
+    CODEDIR="${MOODLE_CI_RUNNER_GITDIR}"
+
+    # Checkout main
+    run git_moodle_checkout main
+    assert_success
+
+    # Run the job
+    run launch_runner
+    assert_success
+    assert_output --partial "== JOBTYPE: jest"
+    assert_output --partial "== Moodle branch (version.php):"
+    assert_output --partial "== Node version: 22"
+    assert_output --partial "== JEST_FILTER:"
+    assert_output --partial "Initialising Jest environment"
+    assert_output --partial "Running: npm test"
+    assert_output --partial "Test Suites:"
+    assert_output --partial "Exporting all docker logs for UUID"
+    assert_output --partial "Stopping and removing all docker containers"
+    assert_output --partial "== Exit code: 0"
+}
+
+@test "Jest tests: run the job for main with filter applied" {
+    # Set all the required variables.
+    JOBTYPE="jest"
+    CODEDIR="${MOODLE_CI_RUNNER_GITDIR}"
+    JEST_FILTER="pendingstrings"
+
+    # Checkout main
+    run git_moodle_checkout main
+    assert_success
+
+    # Run the job
+    run launch_runner
+    assert_success
+    assert_output --partial "== JOBTYPE: jest"
+    assert_output --partial "== Node version: 22"
+    assert_output --partial "== JEST_FILTER: pendingstrings"
+    assert_output --partial "Initialising Jest environment"
+    assert_output --partial "Running: npm test -- --passWithNoTests pendingstrings"
+    assert_output --partial "No tests found"
+    assert_output --partial "== Exit code: 0"
+}


### PR DESCRIPTION
This pull request adds support for running JavaScript (Jest) tests in the Moodle CI runner, alongside existing PHP-based jobs. It introduces a new modular job type for Jest, a supporting Docker module for Node.js containers, and comprehensive Bats-based integration tests. Additionally, it improves compatibility in shared modules for jobs that do not use a PHP webserver.

**New Jest Job Type and Node.js Support:**

* Added a new `jest` job type in `runner/main/jobtypes/jest/jest.sh` that orchestrates Jest test runs in a Node.js Docker container, including setup, configuration, dependency installation, and execution logic.
* Introduced the `docker-node` module in `runner/main/modules/docker-node/docker-node.sh` for provisioning and managing Node.js containers, with appropriate environment and setup functions.
* Created a dedicated Bats test suite in `test/jest_test.bats` to verify Jest job integration, including tests for filtered and unfiltered runs.

**Compatibility Improvements:**

* Updated `docker-logs_teardown` in `docker-logs.sh` to handle jobs that do not set the `WEBSERVER` variable, ensuring correct teardown behavior for non-PHP jobs like Jest.