### PR TITLE
Fix recorder.bsf silently dropping samples with byte session sizes

### DIFF
--- a/runner/main/modules/docker-jmeter/libraries/recorder.bsf
+++ b/runner/main/modules/docker-jmeter/libraries/recorder.bsf
@@ -78,16 +78,20 @@ MoodleResult(JMeterContext ctx) {
         sessUnit = sessUnit.trim();
 
         // Normalise to KB for consistent comparison.
+        // Note: String.format(String, double) cannot be resolved by BeanShell
+        // (varargs + primitive boxing fails with "Static method format(...) not
+        // found"), which aborts the recorder and drops the sample entirely.
+        // Round to 3 decimals arithmetically instead.
         if (sessUnit.equalsIgnoreCase("bytes")) {
-            // Convert bytes to KB (e.g. 569 bytes → 0.569 KB stored as "0.569").
+            // Convert bytes to KB (e.g. 569 bytes → 0.556 KB stored as "0.556").
             double bytesVal = Double.parseDouble(sessValue);
-            sessionsize = String.format("%.3f", bytesVal / 1024.0);
+            sessionsize = String.valueOf(Math.round(bytesVal / 1024.0 * 1000.0) / 1000.0);
         } else if (sessUnit.equalsIgnoreCase("MB")) {
             double mbVal = Double.parseDouble(sessValue);
-            sessionsize = String.format("%.3f", mbVal * 1024.0);
+            sessionsize = String.valueOf(Math.round(mbVal * 1024.0 * 1000.0) / 1000.0);
         } else if (sessUnit.equalsIgnoreCase("GB")) {
             double gbVal = Double.parseDouble(sessValue);
-            sessionsize = String.format("%.3f", gbVal * 1024.0 * 1024.0);
+            sessionsize = String.valueOf(Math.round(gbVal * 1024.0 * 1024.0 * 1000.0) / 1000.0);
         } else {
             // Already KB or no unit — just the numeric value.
             sessionsize = sessValue.trim();


### PR DESCRIPTION
## Summary

- \`recorder.bsf\`'s session-size unit conversion used \`String.format("%.3f", double)\` for the bytes/MB/GB branches. BeanShell cannot resolve that varargs static method overload, so it throws (\`Error invoking bsh method\`) and the whole sample is dropped from \`rundata.php\` - not just that field.
- In the default XS performance test plan this silently removed 3 of 14 scenarios ("Frontpage not logged", "View login page", "Logout") from every \`rundata.json\`, because those requests happen to report session size in bytes. Those scenarios were never regression-checked in CI.
- Fix: replace \`String.format\` with an arithmetic round (\`Math.round(x * 1000.0) / 1000.0\`, stringified via \`String.valueOf\`), which BeanShell resolves fine.

## Test plan

- Ran a local XS performance job before/after the fix (moodle-performance runbook).
- Before: 11 scenarios in \`rundata.json\`, recorder silently drops the 3 byte-denominated ones.
- After: 14 scenarios x 5 loops, 0 ERROR lines in \`jmeter.log\`, e.g. guest session 569 bytes -> "0.556" KB recorded correctly.

Unrelated to #177 (different bug, same file area) so opened separately per maintainer preference for small focused PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)