### PR TITLE
Correct inaccuracies in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,27 @@
 
 This is a **Bash-based CI orchestrator** that runs PHPUnit and Behat tests for Moodle inside Docker containers. It uses a `jobs → modules → stages` model:
 
-- **Jobs** (`runner/main/jobtypes/`): Top-level test types (`phpunit`, `behat`, `postjobs`, `performance`). Each declares which modules it needs and in what order, then implements `_run`.
+- **Jobs** (`runner/main/jobtypes/`): Top-level test types (`phpunit`, `behat`, `jest`, `performance`, `postjobs`). Each declares which modules it needs and in what order, then implements `_run`.
 - **Modules** (`runner/main/modules/`): Reusable units (e.g., `docker`, `docker-php`, `docker-database`, `env`, `git`, `browser`). Like mini-jobs but without `_run` or `_modules`.
-- **Stages**: Executed in fixed order by `runner/main/lib.sh`: `env+check → config → setup → run → teardown` (teardown runs in reverse module order).
+- **Stages**: Executed in a fixed order by `run()` in `runner/main/lib.sh` — see [Stage Order](#stage-order).
 
-**Canonical code lives in `runner/main/`.** All other numbered directories (`runner/31/`, `runner/400/`, etc.) are exact copies kept for historical/version-mapping purposes — only ever edit `runner/main/`.
+**Canonical code lives in `runner/main/`.** Every other entry in `runner/` (`31`, `400`, `502`, `master`, ...) is a **symlink to `main`**, one per supported Moodle branch — they are not independent copies. A change to `runner/main/` therefore takes effect for *every* Moodle branch at once; there is no per-branch insulation, so consider the full supported range when changing pinned image versions or defaults. A symlink can be replaced by a real directory if a branch ever needs to fork, but none currently are. Only ever edit `runner/main/`.
+
+## Stage Order
+
+`run()` executes the stages below. Note the asymmetry: the job's `_env` runs *before* the modules', while the job's `_config` and `_setup` run *after* theirs.
+
+1. `<job>_env`
+2. For each module in `_modules()` order: `<module>_env`, then `<module>_check`
+3. `<job>_check`
+4. Each `<module>_config`
+5. `<job>_config`
+6. Each `<module>_setup`
+7. `<job>_setup`
+8. `<job>_run` — invoked with `set +e`, so the job owns its own exit code
+9. Via `trap` on exit: `<job>_teardown` first, then each `<module>_teardown` in **reverse** `_modules()` order
+
+`_env` functions are declared with `declare -g "${variable}=${!variable:-}"`, so every declared variable exists (empty if unset) and cannot trip `set -u` later.
 
 ## Function Naming Convention
 
@@ -34,8 +50,9 @@ Module names with hyphens (e.g., `docker-php`) use the hyphen in function names 
 
 1. Create `runner/main/jobtypes/<name>/<name>.sh` (job) or `runner/main/modules/<name>/<name>.sh` (module).
 2. Implement all required functions with the name prefix.
-3. For a new job: add it to the `_modules()` list of any job that needs it; reference `test/fixtures/jobtypes/dummy/dummy.sh` as a minimal job template.
-4. Add a corresponding `test/<name>_test.bats` file.
+3. **For a new module**: add it to the `_modules()` list of every job that needs it, at the correct position — ordering is a dependency contract (see [Module Dependency Rules](#module-dependency-rules)).
+   **For a new job**: nothing else needs to reference it; it is selected at runtime with `JOBTYPE=<name>`. Jobs are never listed in another job's `_modules()`. Use `test/fixtures/jobtypes/dummy/dummy.sh` as a minimal template.
+4. Add a corresponding `test/<name>_test.bats` file — the CI workflow picks it up automatically.
 
 ## Key Runtime Variables
 
@@ -46,7 +63,7 @@ Module names with hyphens (e.g., `docker-php`) use the hyphen in function names 
 | `ENVIROPATH` | `env` module | Env file passed to containers via `--env-file` |
 | `WEBSERVER` | `docker-php` module | Container name for the PHP/Apache container |
 | `EXITCODE` | Each job | Accumulated exit code; runner exits with this value |
-| `MOODLE_BRANCH` | `moodle-branch` module | Parsed from `version.php` in `CODEDIR` |
+| `MOODLE_BRANCH` | `moodle-branch` module | `$branch` parsed from `CODEDIR/public/version.php`, falling back to `CODEDIR/version.php` on pre-`public/` layouts |
 
 Variables passed to containers are declared in the job's `_to_env_file()` function; the `env` module writes them to `ENVIROPATH` during setup.
 
@@ -56,12 +73,20 @@ Tests use [Bats](https://github.com/bats-core/bats-core) and require a separate 
 
 ```bash
 export MOODLE_CI_RUNNER_GITDIR=/path/to/moodle.git  # must have full history (fetch-depth: 0)
-bats test/runner_test.bats        # runner/orchestration tests
-bats test/phpunit_test.bats       # PHPUnit job integration tests
-bats test/behat_test.bats         # Behat job integration tests
+export LOCAL_CI_PATH=/path/to/moodle-local_ci       # required by some suites
+
+bats test/runner_test.bats          # runner/orchestration tests
+bats test/phpunit_test.bats         # PHPUnit job integration tests
+bats test/behat_test.bats           # Behat job integration tests
+bats test/jest_test.bats            # Jest job
+bats test/postjobs_test.bats        # postjobs job
+bats test/phpunit_bisect_test.bats  # PHPUnit git-bisect mode
+bats test/behat_bisect_test.bats    # Behat git-bisect mode
 ```
 
-Tests perform **destructive git checkouts** on `MOODLE_CI_RUNNER_GITDIR` — always use a dedicated clone. The `_common_teardown` helper resets it to `main` after each test.
+`.github/workflows/ci.yml` discovers every `test/*.bats` file automatically and runs each as a separate matrix job on push and pull request, so all of the above run in CI without needing to be registered anywhere.
+
+Tests perform **destructive git checkouts** on `MOODLE_CI_RUNNER_GITDIR` — always use a dedicated clone, never a checkout you work in or a shared reference repo. The `_common_teardown` helper resets it to `main` after each test.
 
 The `dummy` job type in `test/fixtures/jobtypes/dummy/` is installed/removed per test suite in `runner_test.bats` — it's the minimal reference for a working job.
 
@@ -85,5 +110,7 @@ Deprecated variable names (`TESTTORUN`, `TAGS`, `TESTSUITE`, `DBSLAVES`, etc.) s
 
 ## Docker Container Lifecycle
 
-All containers share a Docker network (`NETWORK`, default `moodle`) and are named `<role><UUID>` (e.g., `webserver<UUID>`, `pgsql<UUID>`). The `docker` module's `_teardown` stops and removes all containers matching `UUID`. The `docker-php` module mounts `SHAREDDIR` as `/shared` and `COMPOSERCACHE` as `/var/www/.composer`.
+All containers share a Docker network (`NETWORK`, default `moodle`) and are named `<role><UUID>` (e.g., `webserver<UUID>`, `database<UUID>`, `redis<UUID>`, `solr<UUID>`). The role is the service's function, not the product — the database container is `database<UUID>` whatever `DBTYPE` is set to.
+
+The `docker` module's `_teardown` stops and removes all containers matching `UUID`, so any container a new module starts is reaped automatically as long as it follows the `<role><UUID>` naming. The `docker-php` module mounts `SHAREDDIR` as `/shared` and `COMPOSERCACHE` as `/var/www/.composer`.
 


### PR DESCRIPTION
AGENTS.md was generated automatically and several statements did not match the code. Corrected against the source:

- The per-branch directories in runner/ (31, 400, 502, master, ...) are symlinks to main, not "exact copies kept for historical purposes". This matters: a change to runner/main/ applies to every supported Moodle branch at once, which the old wording implied it did not. README.md already described them correctly.
- The jobtypes list omitted jest.
- Adding a new job was described as adding it to another job's _modules() list. Jobs are never listed as modules; they are selected with JOBTYPE. That instruction applies to new modules.
- The example container name pgsql<UUID> does not exist. The database container is database<UUID> regardless of DBTYPE.
- The stage order "env+check -> config -> setup -> run -> teardown" hid that the job's _env runs before the modules', while its _config and _setup run after theirs, and that job teardown precedes module teardown. Documented the actual order from run().
- MOODLE_BRANCH is read from public/version.php with a fallback to version.php, not just version.php.
- The Bats section listed 3 of the 7 suites and omitted LOCAL_CI_PATH.