### PR TITLE
Use PUBLICROOT for the performancetool CLI path

### DIFF
--- a/runner/main/jobtypes/performance/performance.sh
+++ b/runner/main/jobtypes/performance/performance.sh
@@ -285,8 +285,11 @@ function performance_perftoolcmd() {
     # Note: --updateuserspassword ensures the users' passwords in the database match the
     #       password written to the CSV ($CFG->tool_generator_users_password), which is
     #       critical for JMeter to be able to login as those users.
+    # Note: PUBLICROOT is empty on branches predating the public/ directory layout
+    #       (e.g. MOODLE_405_STABLE), where plugins live in local/ rather than
+    #       public/local/. Unlike admin/cli, plugin paths have no root-level shim.
     cmd=(
-        php public/local/performancetool/generate_test_data.php \
+        php ${PUBLICROOT}local/performancetool/generate_test_data.php \
             --size="${SITESIZE}" \
             --planfilespath="/shared" \
             --bypasscheck \


### PR DESCRIPTION
## Summary

The performance jobtype invokes the test-data generator at a hardcoded `public/local/performancetool/generate_test_data.php`. That path only exists on branches using the `public/` directory layout (5.0 onwards), so running the performance job against `MOODLE_405_STABLE` fails — 4.5 has no `public/` directory and the runner installs the plugin at `local/performancetool`.

Use `${PUBLICROOT}` as the behat and phpunit jobtypes already do.

Worth noting why only this line needed changing: the neighbouring `php admin/cli/install_database.php` call works unqualified because Moodle keeps root-level shims for `admin/cli` entry points even on the `public/` layout. There is no equivalent shim for plugin directories, so plugin paths must be qualified.

This is needed to compare 4.5 against main in the performance CI job (AE-188).

## Test plan

Ran the XS performance job locally against both layouts, with PHP and PostgreSQL pinned identically:

- `v4.5.12` (no `public/`, `PUBLICROOT=""`) — exit 0, 14 scenarios x 5 loops, 0 ERROR lines in `jmeter.log`. Fails before this change.
- `main` / 5.3dev (`public/`, `PUBLICROOT="public/"`) — exit 0, 14 scenarios x 5 loops, 0 ERROR lines. Unchanged behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)