### PR TITLE
Skip classic theme Behat suite when checkout has no classic theme

### DIFF
--- a/runner/main/jobtypes/behat/behat.sh
+++ b/runner/main/jobtypes/behat/behat.sh
@@ -197,10 +197,21 @@ function behat_config() {
         BEHAT_RERUNS=0
         BEHAT_TIMING_FILENAME=
     fi
+
+    # The classic theme is being removed (starting from main). "ALL" (boost + classic) has
+    # nothing extra to add when this checkout doesn't have it, so fall back to the default suite.
+    if [[ "${BEHAT_SUITE}" == "ALL" ]] && [[ -z "${MOODLE_HAS_CLASSIC_THEME}" ]]; then
+        BEHAT_SUITE=""
+    fi
 }
 
 # Behat job type setup.
 function behat_setup() {
+    # Nothing to set up: BEHAT_SUITE=classic was requested but this checkout has no classic theme.
+    if [[ "${BEHAT_SUITE}" == "classic" ]] && [[ -z "${MOODLE_HAS_CLASSIC_THEME}" ]]; then
+        return
+    fi
+
     # If both GOOD_COMMIT and BAD_COMMIT are not set, we are going to run a normal session.
     # (for bisect sessions we don't have to setup the environment).
     if [[ -z "${GOOD_COMMIT}" ]] && [[ -z "${BAD_COMMIT}" ]]; then
@@ -261,6 +272,12 @@ function behat_initcmd() {
 
 # Behat job type run.
 function behat_run() {
+    # Nothing to run: BEHAT_SUITE=classic was requested but this checkout has no classic theme.
+    if [[ "${BEHAT_SUITE}" == "classic" ]] && [[ -z "${MOODLE_HAS_CLASSIC_THEME}" ]]; then
+        print_warning "BEHAT_SUITE=classic requested but this checkout has no classic theme, skipping."
+        return
+    fi
+
     # If both GOOD_COMMIT and BAD_COMMIT are not set, we are going to run a normal session.
     if [[ -z "${GOOD_COMMIT}" ]] && [[ -z "${BAD_COMMIT}" ]]; then
         behat_run_normal

--- a/runner/main/modules/moodle-branch/moodle-branch.sh
+++ b/runner/main/modules/moodle-branch/moodle-branch.sh
@@ -21,6 +21,7 @@
 function moodle-branch_env() {
     env=(
         MOODLE_BRANCH
+        MOODLE_HAS_CLASSIC_THEME
     )
     echo "${env[@]}"
 }
@@ -34,9 +35,19 @@ function moodle-branch_check() {
 # Moodle core copy module config.
 function moodle-branch_config() {
     # Get the Moodle branch from code, so we can make decisions based on it.
+    local classicthemedir
     if [[ -d "${CODEDIR}/public" ]]; then
         MOODLE_BRANCH=$(grep "\$branch" "${CODEDIR}"/public/version.php | sed "s/';.*//" | sed "s/^\$.*'//")
+        classicthemedir="${CODEDIR}/public/theme/classic"
     else
         MOODLE_BRANCH=$(grep "\$branch" "${CODEDIR}"/version.php | sed "s/';.*//" | sed "s/^\$.*'//")
+        classicthemedir="${CODEDIR}/theme/classic"
+    fi
+
+    # The classic theme is being removed (starting from main), so callers can no
+    # longer assume it's there just because of the branch name being tested.
+    MOODLE_HAS_CLASSIC_THEME=
+    if [[ -f "${classicthemedir}/version.php" ]]; then
+        MOODLE_HAS_CLASSIC_THEME="yes"
     fi
 }


### PR DESCRIPTION
The classic theme is being removed starting from main, and future release branches cut from it won't have it either.

Detect its presence directly from the checkout (public/theme/classic/version.php) instead of relying on branch naming, so BEHAT_SUITE=classic/ALL requests degrade gracefully once the theme is gone.